### PR TITLE
脚注のtext-indentを修正

### DIFF
--- a/src/style/_counter.styl
+++ b/src/style/_counter.styl
@@ -62,8 +62,6 @@ figure figcaption
 
 span.footnote
   counter-increment: footnote
-  font-weight: 400
-  text-align: left
 
   &::footnote-call
     content: counter(footnote)

--- a/src/style/_element.styl
+++ b/src/style/_element.styl
@@ -85,6 +85,10 @@ pre
 // 脚注
 span.footnote
   float: footnote
+  text-align: left
+  font-weight: 400
+  font-size: 10pt
+  text-indent: 0
 
   &::footnote-call
     font-size: 8px


### PR DESCRIPTION
文章中のスタイルが継承されて、 `text-indent` が変になっていたところがあったので修正しました

![image](https://user-images.githubusercontent.com/7820884/45472657-d950bc80-b76f-11e8-93f8-75615ec2a0dd.png)
